### PR TITLE
run new image generation github workflow every day, instead of weekly

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -3,7 +3,7 @@ name: Build Docker images
 on:
   workflow_dispatch:
   schedule:
-    # run every sunday at midnight
+    # run every day at midnight
     - cron: "0 0 * * *"
   push:
     branches:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # run every sunday at midnight
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -3,7 +3,7 @@ name: Build Docker images
 on:
   workflow_dispatch:
   repository_dispatch:
-    types: [build_images]
+    types: [biome-release-cli-event]
   push:
     branches:
       - main

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -2,9 +2,8 @@ name: Build Docker images
 
 on:
   workflow_dispatch:
-  schedule:
-    # run every day at midnight
-    - cron: "0 0 * * *"
+  repository_dispatch:
+    types: [build_images]
   push:
     branches:
       - main


### PR DESCRIPTION
Closes https://github.com/biomejs/docker/issues/7

Biome releases relatively frequently, and we use these images when we want to upgrade versions to install biome in CI. It would be great if this ran daily to check for new releases. 

